### PR TITLE
Harden file storage internals

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -36,6 +36,8 @@ The file object implements `withResource()` and `withFile()`. The second takes a
 
 When you store a file for the first time in your storage backend, you **must** add a resource to the file object. If you don't do that, you'll get an exception from the file storage service.
 
+The same applies to the UUID when you use the built-in `File` object together with serialization or the default `PathBuilder`: call `withUuid()` before persisting or generating paths.
+
 ## Dependencies
 
 We think there is a need to explain why we have picked the dependencies we have, because we try to keep dependencies low. However, there are some cases that make sense to use existing libraries.

--- a/docs/Path-Builders.md
+++ b/docs/Path-Builders.md
@@ -14,7 +14,10 @@ $builder = new PathBuilder([
 
 ### Options:
 
+ * **directorySeparator**: `DIRECTORY_SEPARATOR`
  * **randomPath**: 'sha1'
+   * Can also be a callable with the signature `function (string $uuid, int $levels): string`
+ * **randomPathLevels**: 3
  * **sanitizeFilename**: true
  * **beautifyFilename**: false
  * **filenameSanitizer**: null|\PhpCollective\Infrastructure\Storage\Utility\FilenameSanitizerInterface
@@ -64,6 +67,8 @@ The following placeholders are only valid when used in a path for a manipulated 
 This path builder provides a `setFilenameSanitizer()` method that takes an object implementing `PhpCollective\Infrastructure\Storage\Utility\FilenameSanitizerInterface`.
 
 This is an alternative way to provide a sanitizer besides passing it through the configuration array.
+
+The `filenameSanitizer` config option and `setFilenameSanitizer()` are equivalent. Use whichever fits your setup better.
 
 ## Conditional Path Builder
 

--- a/docs/The-File-Object.md
+++ b/docs/The-File-Object.md
@@ -53,6 +53,8 @@ You'll also have to add the (uu)id to the file object if your intended path for 
 
 The file object is serializable to json, and you can call `toArray()` on it to turn it into an array that you can either save in the structure you get or continue transforming it into whatever structure your persistence layer expects.
 
+If you want to serialize the built-in `File` object or use the default `PathBuilder`, make sure you set a UUID first using `withUuid()`. The UUID is treated as required state for persistence and default path generation.
+
 ## Restoring the file object
 
 You'll have to reconstruct the file object later from your persisted information when you want to come back to it later and work with new variants for example. Depending on your architecture, your domain model could also simply implement the `FileInterface` if this is more convenient for your.

--- a/src/Exception/MissingUuidException.php
+++ b/src/Exception/MissingUuidException.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+/**
+ * Copyright (c) Florian Krämer (https://florian-kraemer.net)
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright Copyright (c) Florian Krämer (https://florian-kraemer.net)
+ * @author Florian Krämer
+ * @link https://github.com/Phauthentic
+ * @license https://opensource.org/licenses/MIT MIT License
+ */
+
+namespace PhpCollective\Infrastructure\Storage\Exception;
+
+/**
+ * Missing UUID Exception
+ */
+class MissingUuidException extends StorageException
+{
+    /**
+     * @return self
+     */
+    public static function create(): self
+    {
+        return new self(
+            'UUID has not been set',
+        );
+    }
+}

--- a/src/File.php
+++ b/src/File.php
@@ -15,6 +15,7 @@
 namespace PhpCollective\Infrastructure\Storage;
 
 use PhpCollective\Infrastructure\Storage\Exception\InvalidStreamResourceException;
+use PhpCollective\Infrastructure\Storage\Exception\MissingUuidException;
 use PhpCollective\Infrastructure\Storage\PathBuilder\PathBuilderInterface;
 use PhpCollective\Infrastructure\Storage\Processor\Exception\VariantDoesNotExistException;
 use PhpCollective\Infrastructure\Storage\UrlBuilder\UrlBuilderInterface;
@@ -395,10 +396,16 @@ class File implements FileInterface
     }
 
     /**
+     * @throws \PhpCollective\Infrastructure\Storage\Exception\MissingUuidException
+     *
      * @return string
      */
     public function uuid(): string
     {
+        if (!isset($this->uuid)) {
+            throw MissingUuidException::create();
+        }
+
         return $this->uuid;
     }
 
@@ -673,7 +680,7 @@ class File implements FileInterface
     public function toArray(): array
     {
         return [
-            'uuid' => $this->uuid,
+            'uuid' => $this->uuid(),
             'filename' => $this->filename,
             'filesize' => $this->filesize,
             'mimeType' => $this->mimeType,

--- a/src/PathBuilder/PathBuilder.php
+++ b/src/PathBuilder/PathBuilder.php
@@ -72,9 +72,9 @@ class PathBuilder implements PathBuilderInterface
     {
         $this->config = $config + $this->defaultConfig;
 
-        if (!$this->config['filenameSanitizer'] instanceof FilenameSanitizerInterface) {
-            $this->filenameSanitizer = new FilenameSanitizer();
-        }
+        $this->filenameSanitizer = $this->config['filenameSanitizer'] instanceof FilenameSanitizerInterface
+            ? $this->config['filenameSanitizer']
+            : new FilenameSanitizer();
     }
 
     /**
@@ -177,16 +177,21 @@ class PathBuilder implements PathBuilderInterface
      *
      * @param string $string Input string
      * @param int $level Depth of the path to generate.
-     * @param string $method Hash method, crc32 or sha1.
+     * @param callable|string $method Hash method or callback.
+     * @param string $separator Directory separator to use.
      *
      * @throws \InvalidArgumentException
      *
      * @return string
      */
-    protected function randomPath($string, $level = 3, $method = 'sha1'): string
-    {
+    protected function randomPath(
+        string $string,
+        int $level = 3,
+        $method = 'sha1',
+        string $separator = DIRECTORY_SEPARATOR,
+    ): string {
         if ($method === 'sha1') {
-            return $this->randomPathSha1($string, $level);
+            return $this->randomPathSha1($string, $level, $separator);
         }
 
         if (is_callable($method)) {
@@ -206,17 +211,18 @@ class PathBuilder implements PathBuilderInterface
      *
      * @param string $string Input string
      * @param int $level Depth of the path to generate.
+     * @param string $separator Directory separator to use.
      *
      * @return string
      */
-    protected function randomPathSha1(string $string, int $level): string
+    protected function randomPathSha1(string $string, int $level, string $separator): string
     {
         $result = sha1($string);
         $randomString = '';
         $counter = 0;
         for ($i = 1; $i <= $level; $i++) {
             $counter += 2;
-            $randomString .= substr($result, $counter, 2) . DIRECTORY_SEPARATOR;
+            $randomString .= substr($result, $counter, 2) . $separator;
         }
 
         return substr($randomString, 0, -1);
@@ -238,7 +244,7 @@ class PathBuilder implements PathBuilderInterface
     protected function buildPath(FileInterface $file, ?string $variant, array $options = []): string
     {
         $config = $options + $this->config;
-        $ds = $this->config['directorySeparator'];
+        $ds = $config['directorySeparator'];
         $filename = $this->filename($file, $options);
         $hashedVariant = substr(hash('sha1', (string)$variant), 0, 6);
         $template = $variant ? $config['variantPathTemplate'] : $config['pathTemplate'];
@@ -250,7 +256,12 @@ class PathBuilder implements PathBuilderInterface
             '{model}' => $file->model(),
             '{collection}' => $file->collection(),
             '{id}' => $file->uuid(),
-            '{randomPath}' => $this->randomPath($file->uuid(), $randomPathLevels),
+            '{randomPath}' => $this->randomPath(
+                $file->uuid(),
+                $randomPathLevels,
+                $config['randomPath'],
+                $ds,
+            ),
             '{modelId}' => $file->modelId(),
             '{strippedId}' => str_replace('-', '', $file->uuid()),
             '{extension}' => $file->extension(),

--- a/src/StorageService.php
+++ b/src/StorageService.php
@@ -186,7 +186,9 @@ class StorageService implements StorageServiceInterface
     public function storeFile(string $adapter, string $path, string $file, ?Config $config = null): void
     {
         $config = $this->makeConfigIfNeeded($config);
-        $this->adapter($adapter)->write($path, (string)file_get_contents($file), $config);
+        $resource = \PhpCollective\Infrastructure\Storage\openFile($file, 'rb', false);
+        $this->adapter($adapter)->writeStream($path, $resource, $config);
+        fclose($resource);
     }
 
     /**

--- a/src/StorageService.php
+++ b/src/StorageService.php
@@ -186,7 +186,7 @@ class StorageService implements StorageServiceInterface
     public function storeFile(string $adapter, string $path, string $file, ?Config $config = null): void
     {
         $config = $this->makeConfigIfNeeded($config);
-        $resource = \PhpCollective\Infrastructure\Storage\openFile($file, 'rb', false);
+        $resource = openFile($file, 'rb', false);
         $this->adapter($adapter)->writeStream($path, $resource, $config);
         fclose($resource);
     }

--- a/tests/TestCase/FileFactoryTest.php
+++ b/tests/TestCase/FileFactoryTest.php
@@ -30,12 +30,9 @@ class FileFactoryTest extends TestCase
      */
     public function testInvalidUpload(): void
     {
-        /** @var \Psr\Http\Message\UploadedFileInterface|\PHPUnit\Framework\MockObject\MockObject $uploadedFile */
-        $uploadedFile = $this->getMockBuilder(UploadedFileInterface::class)
-            ->getMock();
+        $uploadedFile = $this->createStub(UploadedFileInterface::class);
 
-        $uploadedFile->expects($this->any())
-            ->method('getError')
+        $uploadedFile->method('getError')
             ->willReturn(UPLOAD_ERR_NO_FILE);
 
         $this->expectException(RuntimeException::class);
@@ -47,44 +44,32 @@ class FileFactoryTest extends TestCase
      */
     public function testValidUpload(): void
     {
-        /** @var \Psr\Http\Message\StreamInterface|\PHPUnit\Framework\MockObject\MockObject $stream */
-        $stream = $this->getMockBuilder(StreamInterface::class)
-            ->getMock();
+        $stream = $this->createStub(StreamInterface::class);
 
-        $stream->expects($this->any())
-            ->method('isReadable')
+        $stream->method('isReadable')
             ->willReturn(true);
 
-        $stream->expects($this->any())
-            ->method('isWritable')
+        $stream->method('isWritable')
             ->willReturn(false);
 
-        $stream->expects($this->any())
-            ->method('detach')
+        $stream->method('detach')
             ->willReturn(fopen('composer.json', 'r'));
 
-        /** @var \Psr\Http\Message\UploadedFileInterface|\PHPUnit\Framework\MockObject\MockObject $uploadedFile */
-        $uploadedFile = $this->getMockBuilder(UploadedFileInterface::class)
-            ->getMock();
+        $uploadedFile = $this->createStub(UploadedFileInterface::class);
 
-        $uploadedFile->expects($this->any())
-            ->method('getError')
+        $uploadedFile->method('getError')
             ->willReturn(UPLOAD_ERR_OK);
 
-        $uploadedFile->expects($this->any())
-            ->method('getClientFilename')
+        $uploadedFile->method('getClientFilename')
             ->willReturn('titus.jpg');
 
-        $uploadedFile->expects($this->any())
-            ->method('getSize')
+        $uploadedFile->method('getSize')
             ->willReturn(12345);
 
-        $uploadedFile->expects($this->any())
-            ->method('getClientMediaType')
+        $uploadedFile->method('getClientMediaType')
             ->willReturn('image/image-jpg');
 
-        $uploadedFile->expects($this->any())
-            ->method('getStream')
+        $uploadedFile->method('getStream')
             ->willReturn($stream);
 
         $file = FileFactory::fromUploadedFile($uploadedFile, 'local');

--- a/tests/TestCase/FileTest.php
+++ b/tests/TestCase/FileTest.php
@@ -14,6 +14,7 @@
 
 namespace PhpCollective\Test\TestCase;
 
+use PhpCollective\Infrastructure\Storage\Exception\MissingUuidException;
 use PhpCollective\Infrastructure\Storage\File;
 use PhpCollective\Infrastructure\Storage\FileFactory;
 use PhpCollective\Infrastructure\Storage\FileInterface;
@@ -139,5 +140,35 @@ class FileTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Path has not been set');
         $file->path();
+    }
+
+    /**
+     * @return void
+     */
+    public function testMissingUuidExceptionOnSerialization(): void
+    {
+        $file = File::create(
+            'foobar.jpg',
+            123,
+            'image/jpeg',
+            'local',
+        );
+
+        $this->expectException(MissingUuidException::class);
+        $this->expectExceptionMessage('UUID has not been set');
+        $file->toArray();
+    }
+
+    /**
+     * @return void
+     */
+    public function testMissingUuidExceptionOnPathBuild(): void
+    {
+        $fileOnDisk = $this->getFixtureFile('titus.jpg');
+        $file = FileFactory::fromDisk($fileOnDisk, 'local');
+
+        $this->expectException(MissingUuidException::class);
+        $this->expectExceptionMessage('UUID has not been set');
+        $file->buildPath(new PathBuilder());
     }
 }

--- a/tests/TestCase/PathBuilder/PathBuilderTest.php
+++ b/tests/TestCase/PathBuilder/PathBuilderTest.php
@@ -15,6 +15,7 @@
 namespace PhpCollective\Test\TestCase\PathBuilder;
 
 use DateTime;
+use DateTimeInterface;
 use PhpCollective\Infrastructure\Storage\FileFactory;
 use PhpCollective\Infrastructure\Storage\PathBuilder\PathBuilder;
 use PhpCollective\Infrastructure\Storage\Processor\Image\ImageVariantCollection;
@@ -34,7 +35,7 @@ class PathBuilderTest extends TestCase
         $builder = new class ([
             'pathTemplate' => '{year}{ds}{month}{ds}{day}{ds}{hour}{ds}{minute}',
         ]) extends PathBuilder {
-            protected function getDateObject(): \DateTimeInterface
+            protected function getDateObject(): DateTimeInterface
             {
                 return new DateTime('2020-01-01T20:00:00');
             }

--- a/tests/TestCase/PathBuilder/PathBuilderTest.php
+++ b/tests/TestCase/PathBuilder/PathBuilderTest.php
@@ -18,6 +18,7 @@ use DateTime;
 use PhpCollective\Infrastructure\Storage\FileFactory;
 use PhpCollective\Infrastructure\Storage\PathBuilder\PathBuilder;
 use PhpCollective\Infrastructure\Storage\Processor\Image\ImageVariantCollection;
+use PhpCollective\Infrastructure\Storage\Utility\NoopFilenameSanitizer;
 use PhpCollective\Test\TestCase\TestCase;
 
 /**
@@ -30,19 +31,14 @@ class PathBuilderTest extends TestCase
      */
     public function testDatePaths(): void
     {
-        /** @var \PhpCollective\Infrastructure\Storage\PathBuilder\PathBuilder|\PHPUnit\Framework\MockObject\MockObject $builder */
-        $builder = $this->getMockBuilder(PathBuilder::class)
-            ->setConstructorArgs([
-                [
-                    'pathTemplate' => '{year}{ds}{month}{ds}{day}{ds}{hour}{ds}{minute}',
-                ],
-            ])
-            ->onlyMethods(['getDateObject'])
-            ->getMock();
-
-        $builder->expects($this->any())
-            ->method('getDateObject')
-            ->willReturn((new DateTime('2020-01-01T20:00:00')));
+        $builder = new class ([
+            'pathTemplate' => '{year}{ds}{month}{ds}{day}{ds}{hour}{ds}{minute}',
+        ]) extends PathBuilder {
+            protected function getDateObject(): \DateTimeInterface
+            {
+                return new DateTime('2020-01-01T20:00:00');
+            }
+        };
 
         $file = $this->getFixtureFile('titus.jpg');
         $file = FileFactory::fromDisk($file, 'local')
@@ -66,6 +62,71 @@ class PathBuilderTest extends TestCase
         $result = $builder->path($file);
 
         $this->assertEquals($this->sanitizeSeparator('/fe/c3/b4/914e151291534253a81e7ee2edc1d973/titus.jpg'), $result);
+    }
+
+    /**
+     * @return void
+     */
+    public function testConfiguredFilenameSanitizerIsUsed(): void
+    {
+        $file = $this->getFixtureFile('titus.jpg');
+        $file = FileFactory::fromDisk($file, 'local')
+            ->withUuid('914e1512-9153-4253-a81e-7ee2edc1d973')
+            ->withFilename('foo bar.jpg');
+
+        $builder = new PathBuilder([
+            'filenameSanitizer' => new NoopFilenameSanitizer(),
+        ]);
+
+        $result = $builder->path($file);
+
+        $this->assertStringContainsString(
+            $this->sanitizeSeparator('/foo bar.jpg'),
+            $result,
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testConfiguredRandomPathAndDirectorySeparatorAreUsed(): void
+    {
+        $file = $this->getFixtureFile('titus.jpg');
+        $file = FileFactory::fromDisk($file, 'local')
+            ->withUuid('914e1512-9153-4253-a81e-7ee2edc1d973');
+
+        $builder = new PathBuilder([
+            'directorySeparator' => '-',
+            'randomPath' => static fn (string $uuid, int $level): string => 'custom-path',
+        ]);
+
+        $result = $builder->path($file);
+
+        $this->assertEquals(
+            '-custom-path-914e151291534253a81e7ee2edc1d973-titus.jpg',
+            $result,
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testSha1RandomPathUsesConfiguredDirectorySeparator(): void
+    {
+        $file = $this->getFixtureFile('titus.jpg');
+        $file = FileFactory::fromDisk($file, 'local')
+            ->withUuid('914e1512-9153-4253-a81e-7ee2edc1d973');
+
+        $builder = new PathBuilder([
+            'directorySeparator' => '-',
+        ]);
+
+        $result = $builder->path($file);
+
+        $this->assertSame(
+            '-fe-c3-b4-914e151291534253a81e7ee2edc1d973-titus.jpg',
+            $result,
+        );
     }
 
     /**

--- a/tests/TestCase/StorageServiceTest.php
+++ b/tests/TestCase/StorageServiceTest.php
@@ -14,7 +14,9 @@
 
 namespace PhpCollective\Test\TestCase;
 
+use League\Flysystem\Config;
 use League\Flysystem\Local\LocalFilesystemAdapter;
+use PhpCollective\Infrastructure\Storage\AdapterCollection;
 use PhpCollective\Infrastructure\Storage\StorageAdapterFactory;
 use PhpCollective\Infrastructure\Storage\StorageAdapterFactoryInterface;
 use PhpCollective\Infrastructure\Storage\StorageService;
@@ -69,5 +71,36 @@ class StorageServiceTest extends TestCase
 
         $service->removeFile('local', '/horse/photo.jpg');
         $this->assertFalse($service->fileExists('local', '/horse/photo.jpg'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testStoreFileUsesStreamWrite(): void
+    {
+        $adapter = $this->createMock(LocalFilesystemAdapter::class);
+        $adapter->expects($this->once())
+            ->method('writeStream')
+            ->with(
+                '/horse/photo.jpg',
+                $this->callback(static fn ($resource): bool => is_resource($resource)),
+                $this->isInstanceOf(Config::class),
+            );
+        $adapter->expects($this->never())
+            ->method('write');
+
+        $collection = new AdapterCollection();
+        $collection->add('local', $adapter);
+
+        $service = new StorageService(
+            new StorageAdapterFactory(),
+            $collection,
+        );
+
+        $service->storeFile(
+            'local',
+            '/horse/photo.jpg',
+            $this->getFixtureFile('titus.jpg'),
+        );
     }
 }


### PR DESCRIPTION
## Summary
- fix path builder config handling for custom sanitizers, random path callbacks, and custom separators
- replace raw missing-UUID fatals with an explicit exception and document the UUID requirement
- stream `storeFile()` writes and add regression coverage while cleaning PHPUnit 12 test notices

## Notes
- no intended BC break: this keeps the existing API and turns previous typed-property fatals into explicit runtime exceptions
- local validation passed with `composer test`, `vendor/bin/phpstan analyze --error-format=raw`, `composer cs-fix`, and `composer cs-check`